### PR TITLE
Trim spaces in filenames on Windows

### DIFF
--- a/src/api/module.rs
+++ b/src/api/module.rs
@@ -99,7 +99,7 @@ pub struct File {
 fn sanitise_filename(name: String) -> String {
     if cfg!(windows) {
         sanitize_filename::sanitize_with_options(
-            name,
+            name.trim(),
             sanitize_filename::Options {
                 windows: true,
                 truncate: true,


### PR DESCRIPTION
Windows removes trailing (and possibly leading?) spaces from directory names when created with `fs::create_dir_all`, but doesn't seem to do the same when the space is not trailing in the full path.  For example:

```
"D:\Bernard\Documents\test\MA2216-ST2131\Lecture Slides " -> "D:\Bernard\Documents\test\MA2216-ST2131\Lecture Slides" // trailing space removed
"D:\Bernard\Documents\test\MA2216-ST2131\Lecture Slides \file.txt" -> "D:\Bernard\Documents\test\MA2216-ST2131\Lecture Slides \file.txt" // extra space in the directory name is not removed
```

This causes situations where a file in a subdirectory (`Lecture Slides \file.txt`) fails to be created, because the containing directory (`Lecture Slides `) doesn't already exist (because the directory that was actually created (`Lecture Slides`) doesn't have the trailing space), when the directory on Luminus comes with a trailing space.  The error thrown is:

```
thread 'main' panicked at 'Failed during downloading: "Unable to create file"', src\libcore\result.rs:999:5
```

It is currently an issue with this semester's MA2216/ST2131 module, and it's probably reasonable to assume that the lecturer did not intend to add the trailing space.

I'm not sure if my PR is the best solution, but it does fix the problem for me.